### PR TITLE
Fixed dolphin.json can't persist translated strings when run dolphin localize multiple times

### DIFF
--- a/packages/translate/src/__tests__/utils.test.ts
+++ b/packages/translate/src/__tests__/utils.test.ts
@@ -230,4 +230,38 @@ describe('mergeDolphinJsons', () => {
     mergeDolphinJsons({ newJson, previousJson });
     expect(newJson.strings.key1.localizations.ja.state).toBe('new');
   });
+
+  test('should preserve translated values and states when new JSON has undefined values', () => {
+    const newJson = createBaseDolphinJson({
+      strings: {
+        key1: {
+          comment: 'Same comment',
+          localizations: {
+            en: { value: 'Hello', state: 'new' },
+            ja: { state: 'new' }, // No value in new JSON
+            fr: { state: 'new' }, // No value in new JSON
+          },
+        },
+      },
+    });
+
+    const previousJson = createBaseDolphinJson({
+      strings: {
+        key1: {
+          comment: 'Same comment',
+          localizations: {
+            en: { value: 'Hello', state: 'translated' },
+            ja: { value: 'こんにちは', state: 'reviewed' },
+            fr: { value: 'Bonjour', state: 'reviewed' },
+          },
+        },
+      },
+    });
+
+    mergeDolphinJsons({ newJson, previousJson });
+    expect(newJson.strings.key1.localizations.ja.value).toBe('こんにちは');
+    expect(newJson.strings.key1.localizations.ja.state).toBe('reviewed');
+    expect(newJson.strings.key1.localizations.fr.value).toBe('Bonjour');
+    expect(newJson.strings.key1.localizations.fr.state).toBe('reviewed');
+  });
 });

--- a/packages/translate/src/utils.ts
+++ b/packages/translate/src/utils.ts
@@ -117,6 +117,13 @@ export function mergeDolphinJsons({
       newLocalizationUnit.state = newState;
       newLocalizationUnit.skip =
         previousJson.strings[key]?.localizations[targetLanguage]?.skip;
+      
+      // Preserve the translated value from previous JSON if new JSON doesn't have a value
+      const previousValue = previousJson.strings[key]?.localizations[targetLanguage]?.value;
+      if (newLocalizationUnit.value === undefined && previousValue !== undefined) {
+        newLocalizationUnit.value = previousValue;
+      }
+      
       // merge metadata, new metadata will take precedence over previous metadata, except for "extractedFrom"
       if (
         previousJson.strings[key]?.localizations[targetLanguage]?.metadata ||
@@ -193,6 +200,10 @@ function getState({
     }
     const isTargetDifferent = newTargetUnit.value !== previousTargetUnit.value;
     if (isTargetDifferent) {
+      // If new target has no value but previous does, preserve previous state
+      if (newTargetUnit.value === undefined && previousTargetUnit.value !== undefined) {
+        return previousTargetUnit.state;
+      }
       // TODO: if target changes, we need handle it properly(likely modified manually), for now, we use new state or undefined
       return newTargetUnit.state || 'undefined';
     } else {


### PR DESCRIPTION
When I added new localize strings in Xcode, and run dolphin localize for a second time, my previous strings will be override and all strings will be translated again. Is this a known issue?

See belo json examples, notice in second-run-dolphin.json, some of my strings will change state to "New", despite metadata's state is translated.

        "zh-hant": {
          "state": "new",
          "metadata": {
            "extractedFrom": "undefined",
            "state": "translated"
          }
        },


[after-first-run-dolphin.json](https://github.com/user-attachments/files/21145465/after-first-run-dolphin.json)
[second-run-dolphin.json](https://github.com/user-attachments/files/21145468/second-run-dolphin.json)

After the code change, I verified the issue is fixed. I'm not familiar with the project so this PR is just for identifying the problem, I'm not confident this code is the best fix.
